### PR TITLE
Add logo overlay feature

### DIFF
--- a/service/combiner/combiner.py
+++ b/service/combiner/combiner.py
@@ -63,6 +63,7 @@ class VideoVariantRenderSettings:
   use_continuous_audio: bool = False
   fade_out: bool = False
   overlay_type: Utils.RenderOverlayType = None
+  logo_file: Optional[str] = None
 
   def __init__(self, **kwargs):
     field_names = set([f.name for f in dataclasses.fields(self)])
@@ -79,7 +80,8 @@ class VideoVariantRenderSettings:
         f'use_music_overlay={self.use_music_overlay}, '
         f'use_continuous_audio={self.use_continuous_audio}, '
         f'fade_out={self.fade_out}, '
-        f'overlay_type={self.overlay_type})'
+        f'overlay_type={self.overlay_type}, '
+        f'logo_file={self.logo_file})'
     )
 
 
@@ -641,7 +643,7 @@ def _render_video_variant(
     video_variant: VideoVariant,
     vision_model: GenerativeModel,
     video_language: str,
-) -> Dict[str, str]:
+  ) -> Dict[str, str]:
   """Renders a video variant in all formats.
 
   Args:
@@ -711,6 +713,34 @@ def _render_video_variant(
           f'{video_variant.variant_id} using ffmpeg'
       ),
   )
+  logo_local_path = None
+  if video_variant.render_settings.logo_file:
+    logo_local_path = StorageService.download_gcs_file(
+        file_path=Utils.TriggerFile(
+            f'{gcs_folder_path}/{video_variant.render_settings.logo_file}'
+        ),
+        bucket_name=gcs_bucket_name,
+        output_dir=output_dir,
+    )
+    if logo_local_path:
+      Utils.execute_subprocess_commands(
+          cmds=[
+              'ffmpeg',
+              '-y',
+              '-i',
+              horizontal_combo_path,
+              '-i',
+              logo_local_path,
+              '-filter_complex',
+              'overlay=W-w-10:H-h-10',
+              '-codec:a',
+              'copy',
+              horizontal_combo_path,
+          ],
+          description=(
+              f'overlay logo for horizontal variant {video_variant.variant_id}'
+          ),
+      )
   rendered_paths = {
       Utils.RenderFormatType.HORIZONTAL.value: {
           'path': horizontal_combo_name
@@ -778,6 +808,7 @@ def _render_video_variant(
         ),
         video_filter=format_instructions['blur_filter'],
         ffmpeg_cmds=format_ffmpeg_cmds,
+        logo_file_path=logo_local_path,
     )
 
   StorageService.upload_gcs_dir(
@@ -866,6 +897,7 @@ def _render_format(
     generate_image_assets: bool,
     video_filter: str,
     ffmpeg_cmds: Optional[Sequence[str]],
+    logo_file_path: Optional[str] = None,
 ) -> Dict[str, Union[str, Sequence[str]]]:
   """Renders a video variant in a specific format.
 
@@ -914,6 +946,26 @@ def _render_format(
             'blur filter using ffmpeg'
         ),
     )
+  if logo_file_path:
+    tmp_output = f'{output_video_path}.tmp'
+    os.replace(output_video_path, tmp_output)
+    Utils.execute_subprocess_commands(
+        cmds=[
+            'ffmpeg',
+            '-y',
+            '-i',
+            tmp_output,
+            '-i',
+            logo_file_path,
+            '-filter_complex',
+            'overlay=W-w-10:H-h-10',
+            '-codec:a',
+            'copy',
+            output_video_path,
+        ],
+        description=(f'overlay logo for {format_type} variant {variant_id}'),
+    )
+    os.remove(tmp_output)
   output = {
       'path': format_name,
   }

--- a/ui/src/index.ts
+++ b/ui/src/index.ts
@@ -161,6 +161,15 @@ function renderVariants(gcsFolder: string, renderQueue: RenderQueue): string {
     );
   }
 
+  if (renderQueue.logo && renderQueue.logoFileName) {
+    StorageManager.uploadFile(
+      renderQueue.logo,
+      folder,
+      renderQueue.logoFileName,
+      'image/png'
+    );
+  }
+
   const encodedRenderQueueJson = Utilities.base64Encode(
     JSON.stringify(renderQueue.queue),
     Utilities.Charset.UTF_8

--- a/ui/src/ui/src/app/api-calls/api-calls.service.interface.ts
+++ b/ui/src/ui/src/app/api-calls/api-calls.service.interface.ts
@@ -80,6 +80,7 @@ export interface RenderSettings {
   use_continuous_audio: boolean;
   fade_out: boolean;
   overlay_type?: OverlayType;
+  logo_file?: string;
 }
 
 export interface RenderQueue {
@@ -88,6 +89,8 @@ export interface RenderQueue {
   squareCropAnalysis: any;
   verticalCropAnalysis: any;
   sourceDimensions: { w: number; h: number };
+  logo?: string;
+  logoFileName?: string;
 }
 
 export interface RenderQueueVariant {

--- a/ui/src/ui/src/app/app.component.css
+++ b/ui/src/ui/src/app/app.component.css
@@ -274,3 +274,16 @@ mat-divider {
   margin-bottom: 16px;
   justify-content: start;
 }
+
+.logo-overlay {
+  position: absolute;
+  top: 8px;
+  left: 8px;
+  max-width: 100px;
+  pointer-events: none;
+}
+
+.logo-preview {
+  max-width: 100px;
+  margin-top: 8px;
+}

--- a/ui/src/ui/src/app/app.component.html
+++ b/ui/src/ui/src/app/app.component.html
@@ -329,6 +329,7 @@ limitations under the License.
             />
           </video>
           <canvas #magicCanvas></canvas>
+          <img *ngIf="logoUrl" [src]="logoUrl" class="logo-overlay" />
           <div
             #canvasDragElement
             class="canvas-drag-element"
@@ -441,6 +442,23 @@ limitations under the License.
             <mat-icon>auto_awesome</mat-icon>Generate variants
           </button>
         </div>
+      </div>
+      <div class="row" style="margin-top: 0px">
+        <mat-expansion-panel [disabled]="loading" style="width: 100%">
+          <mat-expansion-panel-header>
+            <mat-panel-title class="prompts-panel">
+              <mat-icon class="panel-icon">branding_watermark</mat-icon>
+              <span>Personalisation</span>
+            </mat-panel-title>
+          </mat-expansion-panel-header>
+          <input
+            type="file"
+            accept="image/*"
+            (change)="onLogoSelected($event)"
+            [disabled]="loading"
+          />
+          <img *ngIf="logoUrl" [src]="logoUrl" class="logo-preview" />
+        </mat-expansion-panel>
       </div>
       <div class="row" style="margin-top: 0px">
         <mat-expansion-panel [disabled]="loading" style="width: 100%">

--- a/ui/src/ui/src/app/app.component.ts
+++ b/ui/src/ui/src/app/app.component.ts
@@ -156,6 +156,10 @@ export class AppComponent {
   fadeOut = false;
   demandGenAssets = true;
   analyseAudio = true;
+  logoFile?: File;
+  logoUrl?: string;
+  logoBase64?: string;
+  logoFileName?: string;
   previousRuns: string[] | undefined;
   previousRenders: PreviousRender[] | undefined;
   encodedUserId: string | undefined;
@@ -334,6 +338,22 @@ export class AppComponent {
 
   onFileSelected(file?: File) {
     this.selectedFile = file;
+  }
+
+  onLogoSelected(event: Event) {
+    const input = event.target as HTMLInputElement;
+    const file = input.files && input.files[0];
+    if (file) {
+      this.logoFile = file;
+      this.logoFileName = StringUtil.gcsSanitise(file.name);
+      const reader = new FileReader();
+      reader.onload = () => {
+        const dataUrl = reader.result as string;
+        this.logoUrl = dataUrl;
+        this.logoBase64 = dataUrl.split(',')[1];
+      };
+      reader.readAsDataURL(file);
+    }
   }
 
   getCurrentCropAreaFrame(entities: any[]):
@@ -1107,6 +1127,7 @@ export class AppComponent {
       use_continuous_audio: this.audioSettings === 'continuous',
       fade_out: this.fadeOut,
       overlay_type: this.overlaySettings,
+      logo_file: this.logoFileName,
     };
     const selectedScenes = selectedSegments.map(
       (segment: AvSegment) => segment.av_segment_id
@@ -1178,6 +1199,10 @@ export class AppComponent {
         : 'segment';
     this.fadeOut = variant.render_settings.fade_out;
     this.overlaySettings = variant.render_settings.overlay_type!;
+    this.logoFileName = variant.render_settings.logo_file;
+    if (this.logoFileName) {
+      this.logoUrl = `${CONFIG.cloudStorage.authenticatedEndpointBase}/${CONFIG.cloudStorage.bucket}/${encodeURIComponent(this.folder)}/${this.logoFileName}`;
+    }
     this.closeRenderQueueSidenav();
     setTimeout(() => {
       this.loadingVariant = false;
@@ -1204,6 +1229,8 @@ export class AppComponent {
           w: this.previewVideoElem.nativeElement.videoWidth,
           h: this.previewVideoElem.nativeElement.videoHeight,
         },
+        logo: this.logoBase64,
+        logoFileName: this.logoFileName,
       })
       .subscribe({
         next: combosFolder => {


### PR DESCRIPTION
## Summary
- support logo image in `RenderSettings` and render queue
- upload logo via Apps Script before rendering
- overlay logo on preview and final variants
- allow logo upload in UI with preview

## Testing
- `npm test` in `/ui` *(no tests found)*
- `npm test` in `/ui/src/ui` *(fails: Chrome binary missing)*

------
https://chatgpt.com/codex/tasks/task_e_6885fa513dc883328ca590935a23ea0a