### PR TITLE
Add legal text overlay option

### DIFF
--- a/ui/src/ui/src/app/app.component.css
+++ b/ui/src/ui/src/app/app.component.css
@@ -77,6 +77,25 @@ segments-list {
   pointer-events: none;
 }
 
+.legal-overlay {
+  position: absolute;
+  bottom: 0;
+  left: 50%;
+  transform: translateX(-50%);
+  font-size: 12px;
+  background: rgba(0, 0, 0, 0.5);
+  color: white;
+  padding: 2px 4px;
+  pointer-events: none;
+  z-index: 2;
+  white-space: pre-wrap;
+}
+
+.legal-input-row {
+  gap: 8px;
+  margin-top: 8px;
+}
+
 .canvas-drag-element {
   cursor: move;
   overflow: hidden;

--- a/ui/src/ui/src/app/app.component.html
+++ b/ui/src/ui/src/app/app.component.html
@@ -338,7 +338,17 @@ limitations under the License.
             [cdkDragFreeDragPosition]="dragPosition"
             style="visibility: hidden"
           ></div>
+          <div class="legal-overlay" *ngIf="legalOverlayText">{{ legalOverlayText }}</div>
         </div>
+      </div>
+      <div class="row legal-input-row">
+        <mat-form-field subscriptSizing="dynamic" style="width: 200px">
+          <mat-label>Enter Legal Text</mat-label>
+          <input matInput [(ngModel)]="legalTextInput" />
+        </mat-form-field>
+        <button mat-raised-button color="primary" (click)="applyLegalText()">
+          Apply
+        </button>
       </div>
       <div class="row">
         <div

--- a/ui/src/ui/src/app/app.component.ts
+++ b/ui/src/ui/src/app/app.component.ts
@@ -192,6 +192,8 @@ export class AppComponent {
   businessObjectives = Object.values(CONFIG.vertexAi.abcdBusinessObjectives);
   segmentMarkers: Record<string, SegmentMarker[]> = {};
   segmentSplitting = false;
+  legalTextInput = '';
+  legalOverlayText = '';
 
   @ViewChild('VideoComboComponent') VideoComboComponent?: VideoComboComponent;
   @ViewChild('previewVideoElem')
@@ -1340,6 +1342,10 @@ export class AppComponent {
   toggleContentDisplay() {
     this.evalPromptTextarea!.nativeElement.style.display = 'block';
     this.evalPromptPlaceholder!.nativeElement.style.display = 'none';
+  }
+
+  applyLegalText() {
+    this.legalOverlayText = this.legalTextInput;
   }
 
   updateVideoPreview() {


### PR DESCRIPTION
## Summary
- allow entering a legal disclaimer for the preview video
- show the entered legal text as an overlay when applied

## Testing
- `npm install` in `ui`
- `npm test` in `ui`

------
https://chatgpt.com/codex/tasks/task_e_6888a03cbf0083328d200c0ad0f858d7