### PR TITLE
Add legal text overlay in editing

### DIFF
--- a/ui/src/ui/src/app/app.component.css
+++ b/ui/src/ui/src/app/app.component.css
@@ -274,3 +274,17 @@ mat-divider {
   margin-bottom: 16px;
   justify-content: start;
 }
+
+.legal-overlay {
+  position: absolute;
+  bottom: 0;
+  left: 50%;
+  transform: translateX(-50%);
+  background: rgba(0, 0, 0, 0.5);
+  color: #ffffff;
+  font-size: 12px;
+  padding: 2px 4px;
+  pointer-events: none;
+  border-radius: 2px;
+  margin-bottom: 4px;
+}

--- a/ui/src/ui/src/app/app.component.html
+++ b/ui/src/ui/src/app/app.component.html
@@ -308,6 +308,7 @@ limitations under the License.
           [segmentMarkers]="segmentMarkers"
           (seekToSegmentEvent)="seekToSegment($event)"
           (segmentSplitEvent)="splitSegment($event)"
+          (legalTextApplied)="setLegalOverlay($event)"
         ></segments-list>
         <div
           [hidden]="segmentModeToggle.value !== 'preview'"
@@ -338,6 +339,7 @@ limitations under the License.
             [cdkDragFreeDragPosition]="dragPosition"
             style="visibility: hidden"
           ></div>
+          <div *ngIf="legalOverlayText" class="legal-overlay">{{ legalOverlayText }}</div>
         </div>
       </div>
       <div class="row">

--- a/ui/src/ui/src/app/app.component.ts
+++ b/ui/src/ui/src/app/app.component.ts
@@ -192,6 +192,7 @@ export class AppComponent {
   businessObjectives = Object.values(CONFIG.vertexAi.abcdBusinessObjectives);
   segmentMarkers: Record<string, SegmentMarker[]> = {};
   segmentSplitting = false;
+  legalOverlayText = '';
 
   @ViewChild('VideoComboComponent') VideoComboComponent?: VideoComboComponent;
   @ViewChild('previewVideoElem')
@@ -1363,5 +1364,9 @@ export class AppComponent {
       },
       error: err => this.failHandler(err),
     });
+  }
+
+  setLegalOverlay(text: string) {
+    this.legalOverlayText = text;
   }
 }

--- a/ui/src/ui/src/app/segments-list/segments-list.component.html
+++ b/ui/src/ui/src/app/segments-list/segments-list.component.html
@@ -193,14 +193,22 @@ limitations under the License.
         </div>
       </div>
     }
+    </div>
   </div>
-</div>
 
-<div
-  *ngIf="segmentList === undefined"
-  style="
-    display: flex;
-    flex-direction: column;
+  <div class="legal-input-row" style="display: flex; align-items: center; gap: 8px; margin: 8px 0">
+    <mat-form-field style="flex: 1" appearance="outline">
+      <mat-label>Enter Legal Text</mat-label>
+      <input matInput [(ngModel)]="legalText" />
+    </mat-form-field>
+    <button mat-raised-button color="primary" (click)="applyLegalText()">Apply</button>
+  </div>
+
+  <div
+    *ngIf="segmentList === undefined"
+    style="
+      display: flex;
+      flex-direction: column;
     align-items: center;
     justify-content: center;
     width: 320px;

--- a/ui/src/ui/src/app/segments-list/segments-list.component.ts
+++ b/ui/src/ui/src/app/segments-list/segments-list.component.ts
@@ -31,12 +31,15 @@ import {
   QueryList,
   ViewChildren,
 } from '@angular/core';
+import { FormsModule } from '@angular/forms';
 import { MatButtonModule } from '@angular/material/button';
 import { MatButtonToggleModule } from '@angular/material/button-toggle';
 import { MatChipsModule } from '@angular/material/chips';
 import { MatIconModule } from '@angular/material/icon';
 import { MatProgressSpinnerModule } from '@angular/material/progress-spinner';
 import { MatTooltipModule } from '@angular/material/tooltip';
+import { MatFormFieldModule } from '@angular/material/form-field';
+import { MatInputModule } from '@angular/material/input';
 
 import { CONFIG } from '../../../../config';
 import {
@@ -55,6 +58,9 @@ import {
     MatIconModule,
     MatProgressSpinnerModule,
     MatTooltipModule,
+    MatFormFieldModule,
+    MatInputModule,
+    FormsModule,
     CdkDropList,
     CdkDrag,
     ScrollingModule,
@@ -71,6 +77,9 @@ export class SegmentsListComponent {
 
   @Output() seekToSegmentEvent = new EventEmitter<string>();
   @Output() segmentSplitEvent = new EventEmitter<SegmentMarker[]>();
+  @Output() legalTextApplied = new EventEmitter<string>();
+
+  legalText = '';
 
   @ViewChildren('segmentVideoElem')
   segmentVideoElems?: QueryList<ElementRef<HTMLVideoElement>>;
@@ -229,5 +238,9 @@ export class SegmentsListComponent {
       (segment: AvSegment) => segment.av_segment_id === segmentId
     ).splitting = true;
     this.clearSegmentMarkers(segmentId);
+  }
+
+  applyLegalText() {
+    this.legalTextApplied.emit(this.legalText);
   }
 }


### PR DESCRIPTION
## Summary
- enable legal text input for split marker section
- emit and apply legal overlay text on video preview
- style overlay for readability

## Testing
- `npm run build`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6888a03cbf0083328d200c0ad0f858d7