### PR TITLE
Add legal disclaimer overlay

### DIFF
--- a/service/combiner/combiner.py
+++ b/service/combiner/combiner.py
@@ -96,6 +96,7 @@ class VideoVariantSegment:
   av_segment_id: int
   start_s: float
   end_s: float
+  legal_disclaimer: str | None = None
 
   def __init__(self, **kwargs):
     field_names = set([f.name for f in dataclasses.fields(self)])
@@ -107,7 +108,8 @@ class VideoVariantSegment:
     return (
         f'VideoVariantSegment(av_segment_id={self.av_segment_id}, '
         f'start_s={self.start_s}, '
-        f'end_s={self.end_s})'
+        f'end_s={self.end_s}, '
+        f'legal_disclaimer={self.legal_disclaimer})'
     )
 
 
@@ -677,6 +679,16 @@ def _render_video_variant(
       )
   )
   video_duration = Utils.get_media_duration(video_file_path)
+  sorted_segments = sorted(
+      video_variant.av_segments.values(), key=lambda s: s.start_s
+  )
+  legal_overlays = []
+  cum = 0
+  for seg in sorted_segments:
+    seg_duration = seg.end_s - seg.start_s
+    if seg.legal_disclaimer:
+      legal_overlays.append((cum, cum + seg_duration, seg.legal_disclaimer))
+    cum += seg_duration
   (
       full_av_select_filter,
       music_overlay_select_filter,
@@ -686,6 +698,7 @@ def _render_video_variant(
       has_audio,
       video_variant.render_settings,
       video_duration,
+      legal_overlays,
   )
 
   ffmpeg_cmds = _get_variant_ffmpeg_commands(
@@ -1328,6 +1341,7 @@ def _build_ffmpeg_filters(
     has_audio: bool,
     render_settings: VideoVariantRenderSettings,
     video_duration: float,
+    legal_overlays: Optional[Sequence[Tuple[float, float, str]]] = None,
 ) -> Tuple[str, str, str]:
   """Builds the ffmpeg filters.
 
@@ -1383,12 +1397,13 @@ def _build_ffmpeg_filters(
     case Utils.RenderOverlayType.VARIANT_START.value | _:
       overlay_start = variant_first_segment_start
 
+  base_video_label = '[basev]'
   full_av_select_filter = ''.join(
       video_select_filter + audio_select_filter + select_filter_concat
-      + [f'concat=n={idx}:v=1:a=1[outv][outa]', fade_out_filter]
+      + [f'concat=n={idx}:v=1:a=1{base_video_label}[outa]', fade_out_filter]
   ) if has_audio else ''.join(
       video_select_filter + select_filter_concat
-      + [f'concat=n={idx}:v=1[outv]']
+      + [f'concat=n={idx}:v=1{base_video_label}']
   )
 
   music_overlay_select_filter = ''.join(
@@ -1397,7 +1412,7 @@ def _build_ffmpeg_filters(
           f"[2:a]aselect='between(t,{overlay_start},{overlay_start+duration})'"
           ',asetpts=N/SR/TB[music];'
       ] + select_filter_concat + [
-          f'concat=n={idx}:v=1:a=1[outv][tempa];',
+          f'concat=n={idx}:v=1:a=1[basev][tempa];',
           '[tempa][music]amerge=inputs=2[outa]',
           fade_out_filter,
       ]
@@ -1407,8 +1422,34 @@ def _build_ffmpeg_filters(
           f"[0:a]aselect='between(t,{overlay_start},{overlay_start+duration})'"
           ',asetpts=N/SR/TB[outa];'
       ] + [entry for entry in select_filter_concat if entry.startswith('[v')]
-      + [f'concat=n={idx}:v=1[outv]', fade_out_filter]
+      + [f'concat=n={idx}:v=1[basev]', fade_out_filter]
   ) if has_audio else ''
+
+  disclaimer_filter = ''
+  if legal_overlays:
+    current_label = '[basev]'
+    for i, (start, end, text) in enumerate(legal_overlays):
+      next_label = '[outv]' if i == len(legal_overlays) - 1 else f'[ld{i}]'
+      escaped = text.replace("'", "\\'")
+      disclaimer_filter += (
+          f"{current_label}drawtext=text='{escaped}':fontcolor=white:fontsize=20:"
+          "box=1:boxcolor=black@0.5:x=(w-text_w)/2:y=h-(text_h+20):"
+          f"enable='between(t,{start},{end})'{next_label};"
+      )
+      current_label = next_label
+  else:
+    disclaimer_filter = '[basev]copy[outv]'
+  disclaimer_filter = disclaimer_filter.rstrip(';')
+
+  full_av_select_filter = ';'.join([full_av_select_filter, disclaimer_filter])
+  if music_overlay_select_filter:
+    music_overlay_select_filter = ';'.join([
+        music_overlay_select_filter, disclaimer_filter
+    ])
+  if continuous_audio_select_filter:
+    continuous_audio_select_filter = ';'.join([
+        continuous_audio_select_filter, disclaimer_filter
+    ])
 
   return (
       full_av_select_filter,

--- a/ui/src/ui/src/app/api-calls/api-calls.service.interface.ts
+++ b/ui/src/ui/src/app/api-calls/api-calls.service.interface.ts
@@ -45,6 +45,7 @@ export interface AvSegment {
   splitting?: boolean;
   played?: boolean;
   segment_screenshot_uri?: string;
+  legal_disclaimer?: string;
 }
 
 export interface GenerateVariantsResponse {

--- a/ui/src/ui/src/app/app.component.ts
+++ b/ui/src/ui/src/app/app.component.ts
@@ -1097,6 +1097,7 @@ export class AppComponent {
         start_s: segment.start_s,
         end_s: segment.end_s,
         segment_screenshot_uri: segment.segment_screenshot_uri,
+        legal_disclaimer: segment.legal_disclaimer,
       };
     });
     const renderSettings: RenderSettings = {

--- a/ui/src/ui/src/app/segments-list/segments-list.component.css
+++ b/ui/src/ui/src/app/segments-list/segments-list.component.css
@@ -153,6 +153,20 @@ video {
   height: var(--filmstrip-image-height);
 }
 
+.legal-overlay {
+  position: absolute;
+  bottom: 0;
+  left: 50%;
+  transform: translateX(-50%);
+  background-color: rgba(0, 0, 0, 0.5);
+  color: #fff;
+  font-size: 12px;
+  padding: 2px 4px;
+  pointer-events: none;
+  max-width: 100%;
+  text-align: center;
+}
+
 .active-segment .drag-element::before {
   content: '';
   position: absolute;

--- a/ui/src/ui/src/app/segments-list/segments-list.component.html
+++ b/ui/src/ui/src/app/segments-list/segments-list.component.html
@@ -92,6 +92,9 @@ limitations under the License.
                 "
                 src="{{ segment.segment_screenshot_uri.replace('.0', '') }}"
               />
+              <div class="legal-overlay" *ngIf="segment.legal_disclaimer">
+                {{ segment.legal_disclaimer }}
+              </div>
             } @else {
               <div style="position: relative">
                 <video
@@ -109,6 +112,9 @@ limitations under the License.
                   class="video-canvas"
                   attr.id="vid-{{ segment.av_segment_id }}"
                 ></canvas>
+                <div class="legal-overlay" *ngIf="segment.legal_disclaimer">
+                  {{ segment.legal_disclaimer }}
+                </div>
               </div>
             }
             <mat-icon class="selection-icon" *ngIf="allowSelection">
@@ -186,6 +192,13 @@ limitations under the License.
                   [disabled]="!hasSegmentMarkers(segment.av_segment_id)"
                 >
                   <mat-icon>delete_forever</mat-icon>Clear markers
+                </button>
+                <mat-form-field style="width: 200px; margin-left: 8px" subscriptSizing="dynamic">
+                  <mat-label>Legal Disclaimer</mat-label>
+                  <input matInput [(ngModel)]="segment.legalInput" />
+                </mat-form-field>
+                <button mat-mini-button color="primary" (click)="applyLegalDisclaimer(segment.av_segment_id)">
+                  Apply
                 </button>
               </div>
             }

--- a/ui/src/ui/src/app/segments-list/segments-list.component.ts
+++ b/ui/src/ui/src/app/segments-list/segments-list.component.ts
@@ -37,6 +37,7 @@ import { MatChipsModule } from '@angular/material/chips';
 import { MatIconModule } from '@angular/material/icon';
 import { MatProgressSpinnerModule } from '@angular/material/progress-spinner';
 import { MatTooltipModule } from '@angular/material/tooltip';
+import { FormsModule } from '@angular/forms';
 
 import { CONFIG } from '../../../../config';
 import {
@@ -55,6 +56,7 @@ import {
     MatIconModule,
     MatProgressSpinnerModule,
     MatTooltipModule,
+    FormsModule,
     CdkDropList,
     CdkDrag,
     ScrollingModule,
@@ -206,6 +208,15 @@ export class SegmentsListComponent {
     context?.clearRect(0, 0, canvas?.width ?? 0, canvas?.height ?? 0);
     this.segmentMarkerPositions[segmentId] = [];
     this.segmentMarkers[segmentId] = [];
+  }
+
+  applyLegalDisclaimer(segmentId: string) {
+    const segment = this.segmentList!.find(
+      (s: AvSegment) => s.av_segment_id === segmentId
+    );
+    if (segment) {
+      segment.legal_disclaimer = (segment as any).legalInput || '';
+    }
   }
 
   drawMarker(segmentId: string, marker: SegmentMarker) {


### PR DESCRIPTION
## Summary
- allow segments to include legal disclaimer text
- show legal disclaimer input and overlay in segments list
- send legal disclaimer to render queue and backend
- overlay legal text in rendered videos

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6888b1d38e048332bf1e5ac96c8ddad3