### PR TITLE
Add legal disclaimer overlay per segment

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -18,7 +18,7 @@
       "devDependencies": {
         "@types/cross-spawn": "^6.0.6",
         "@types/fs-extra": "^11.0.4",
-        "@types/node": "^20.12.7"
+        "@types/node": "^20.19.9"
       },
       "engines": {
         "node": ">=20"
@@ -56,13 +56,13 @@
       }
     },
     "node_modules/@types/node": {
-      "version": "20.17.16",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.17.16.tgz",
-      "integrity": "sha512-vOTpLduLkZXePLxHiHsBLp98mHGnl8RptV4YAO3HfKO5UHjDvySGbxKtpYfy8Sx5+WKcgc45qNreJJRVM3L6mw==",
+      "version": "20.19.9",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.19.9.tgz",
+      "integrity": "sha512-cuVNgarYWZqxRJDQHEB58GEONhOK79QVR/qYx4S7kcUObQvUwvFnYxJuuHUKm2aieN9X3yZB4LZsuYNU1Qphsw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "undici-types": "~6.19.2"
+        "undici-types": "~6.21.0"
       }
     },
     "node_modules/ansi-regex": {
@@ -491,9 +491,9 @@
       }
     },
     "node_modules/undici-types": {
-      "version": "6.19.8",
-      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.19.8.tgz",
-      "integrity": "sha512-ve2KP6f/JnbPBFyobGHuerC9g1FYGn/F8n1LWTwNxCEzd6IfqTwUQcNXgEtmmQ6DlRrC1hrSrBnCZPokRrDHjw==",
+      "version": "6.21.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz",
+      "integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==",
       "dev": true,
       "license": "MIT"
     },

--- a/package.json
+++ b/package.json
@@ -39,6 +39,6 @@
   "devDependencies": {
     "@types/cross-spawn": "^6.0.6",
     "@types/fs-extra": "^11.0.4",
-    "@types/node": "^20.12.7"
+    "@types/node": "^20.19.9"
   }
 }

--- a/service/combiner/combiner.py
+++ b/service/combiner/combiner.py
@@ -690,11 +690,19 @@ def _render_video_variant(
       video_duration,
   )
 
-  legal_disclaimers = [
-      (segment.legal_disclaimer_text, segment.start_s, segment.end_s)
-      for segment in video_variant.av_segments.values()
-      if getattr(segment, 'legal_disclaimer_text', None)
-  ]
+  legal_disclaimers = []
+  current_offset = 0.0
+  for segment in video_variant.av_segments.values():
+    duration = segment.end_s - segment.start_s
+    if getattr(segment, 'legal_disclaimer_text', None):
+      legal_disclaimers.append(
+          (
+              segment.legal_disclaimer_text,
+              current_offset,
+              current_offset + duration,
+          )
+      )
+    current_offset += duration
 
   ffmpeg_cmds = _get_variant_ffmpeg_commands(
       video_file_path=video_file_path,

--- a/service/combiner/combiner.py
+++ b/service/combiner/combiner.py
@@ -96,6 +96,7 @@ class VideoVariantSegment:
   av_segment_id: int
   start_s: float
   end_s: float
+  legal_disclaimer_text: str | None = None
 
   def __init__(self, **kwargs):
     field_names = set([f.name for f in dataclasses.fields(self)])
@@ -107,7 +108,8 @@ class VideoVariantSegment:
     return (
         f'VideoVariantSegment(av_segment_id={self.av_segment_id}, '
         f'start_s={self.start_s}, '
-        f'end_s={self.end_s})'
+        f'end_s={self.end_s}, '
+        f'legal_disclaimer_text={self.legal_disclaimer_text})'
     )
 
 
@@ -688,6 +690,12 @@ def _render_video_variant(
       video_duration,
   )
 
+  legal_disclaimers = [
+      (segment.legal_disclaimer_text, segment.start_s, segment.end_s)
+      for segment in video_variant.av_segments.values()
+      if getattr(segment, 'legal_disclaimer_text', None)
+  ]
+
   ffmpeg_cmds = _get_variant_ffmpeg_commands(
       video_file_path=video_file_path,
       speech_track_path=speech_track_path,
@@ -698,6 +706,7 @@ def _render_video_variant(
       full_av_select_filter=full_av_select_filter,
       music_overlay_select_filter=music_overlay_select_filter,
       continuous_audio_select_filter=continuous_audio_select_filter,
+      legal_disclaimers=legal_disclaimers,
   )
 
   horizontal_combo_name = f'combo_{video_variant.variant_id}_h{video_ext}'
@@ -764,6 +773,7 @@ def _render_video_variant(
           full_av_select_filter=full_av_select_filter,
           music_overlay_select_filter=music_overlay_select_filter,
           continuous_audio_select_filter=continuous_audio_select_filter,
+          legal_disclaimers=legal_disclaimers,
       )
     rendered_paths[format_type] = _render_format(
         vision_model=vision_model,
@@ -821,6 +831,7 @@ def _get_variant_ffmpeg_commands(
     full_av_select_filter: str,
     music_overlay_select_filter: str,
     continuous_audio_select_filter: str,
+    legal_disclaimers: Optional[Sequence[Tuple[str, float, float]]] = None,
 ):
   ffmpeg_cmds = [
       'ffmpeg',
@@ -840,6 +851,18 @@ def _get_variant_ffmpeg_commands(
       ffmpeg_filter = [continuous_audio_select_filter]
     elif music_overlay:
       ffmpeg_filter = [music_overlay_select_filter, '-ac', '2']
+  if legal_disclaimers:
+    disclaimer_filter = ffmpeg_filter[0]
+    last_label = 'outv'
+    for i, (text, start, end) in enumerate(legal_disclaimers):
+      out_label = 'outv' if i == len(legal_disclaimers) - 1 else f'ld{i}'
+      escaped = text.replace("'", "\\'").replace(':', '\\:')
+      disclaimer_filter += (
+          f";[{last_label}]drawtext=text='{escaped}':x=(w-text_w)/2:y=h-line_h-10"
+          f":fontcolor=white:fontsize=24:box=1:boxcolor=black@0.5:enable='between(t,{start},{end})'[{out_label}]"
+      )
+      last_label = out_label
+    ffmpeg_filter = [disclaimer_filter]
   ffmpeg_cmds.extend([
       '-filter_complex',
   ] + ffmpeg_filter + [

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -10,7 +10,8 @@
     "forceConsistentCasingInFileNames": true,
     "resolveJsonModule": true,
     "allowUnreachableCode": false,
-    "allowUnusedLabels": false
+    "allowUnusedLabels": false,
+    "types": ["node"]
   },
   "exclude": [
     "node_modules", "service", "ui"

--- a/ui/src/ui/src/app/api-calls/api-calls.service.interface.ts
+++ b/ui/src/ui/src/app/api-calls/api-calls.service.interface.ts
@@ -45,6 +45,7 @@ export interface AvSegment {
   splitting?: boolean;
   played?: boolean;
   segment_screenshot_uri?: string;
+  legal_disclaimer_text?: string;
 }
 
 export interface GenerateVariantsResponse {

--- a/ui/src/ui/src/app/app.component.ts
+++ b/ui/src/ui/src/app/app.component.ts
@@ -1097,6 +1097,7 @@ export class AppComponent {
         start_s: segment.start_s,
         end_s: segment.end_s,
         segment_screenshot_uri: segment.segment_screenshot_uri,
+        legal_disclaimer_text: segment.legal_disclaimer_text,
       };
     });
     const renderSettings: RenderSettings = {

--- a/ui/src/ui/src/app/segments-list/segments-list.component.html
+++ b/ui/src/ui/src/app/segments-list/segments-list.component.html
@@ -117,6 +117,12 @@ limitations under the License.
             <mat-chip *ngIf="segmentMode === 'preview'" class="duration-chip"
               >{{ segment.duration_s.toFixed(2) }}s</mat-chip
             >
+            <div
+              *ngIf="segmentMode === 'preview' && segment.legal_disclaimer_text"
+              style="position: absolute; bottom: 8px; left: 50%; transform: translateX(-50%); background: rgba(0,0,0,0.5); color: white; font-size: 0.85em; pointer-events: none; z-index: 10;"
+            >
+              {{ segment.legal_disclaimer_text }}
+            </div>
           </div>
           <div class="current-segment-info" *ngIf="segmentMode === 'segments'">
             <span class="segment-number">
@@ -186,6 +192,22 @@ limitations under the License.
                   [disabled]="!hasSegmentMarkers(segment.av_segment_id)"
                 >
                   <mat-icon>delete_forever</mat-icon>Clear markers
+                </button>
+              </div>
+              <div class="marker-buttons" style="margin-top: 8px;">
+                <input
+                  type="text"
+                  [(ngModel)]="legalDisclaimerTexts[segment.av_segment_id]"
+                  placeholder="Legal disclaimer"
+                  style="flex: 1; margin-right: 4px;"
+                />
+                <button
+                  type="button"
+                  mat-mini-button
+                  color="primary"
+                  (click)="applyLegalDisclaimer(segment.av_segment_id)"
+                >
+                  Apply
                 </button>
               </div>
             }

--- a/ui/src/ui/src/app/segments-list/segments-list.component.html
+++ b/ui/src/ui/src/app/segments-list/segments-list.component.html
@@ -193,22 +193,22 @@ limitations under the License.
                 >
                   <mat-icon>delete_forever</mat-icon>Clear markers
                 </button>
-              </div>
-              <div class="marker-buttons" style="margin-top: 8px;">
-                <input
-                  type="text"
-                  [(ngModel)]="legalDisclaimerTexts[segment.av_segment_id]"
-                  placeholder="Legal disclaimer"
-                  style="flex: 1; margin-right: 4px;"
-                />
-                <button
-                  type="button"
-                  mat-mini-button
-                  color="primary"
-                  (click)="applyLegalDisclaimer(segment.av_segment_id)"
-                >
-                  Apply
-                </button>
+                <div style="display: flex; margin-top: 8px;">
+                  <input
+                    type="text"
+                    [(ngModel)]="legalDisclaimerTexts[segment.av_segment_id]"
+                    placeholder="Legal disclaimer"
+                    style="flex: 1; margin-right: 4px;"
+                  />
+                  <button
+                    type="button"
+                    mat-mini-button
+                    color="primary"
+                    (click)="applyLegalDisclaimer(segment.av_segment_id)"
+                  >
+                    Apply
+                  </button>
+                </div>
               </div>
             }
           </div>

--- a/ui/src/ui/src/app/segments-list/segments-list.component.html
+++ b/ui/src/ui/src/app/segments-list/segments-list.component.html
@@ -80,18 +80,37 @@ limitations under the License.
             "
           >
             @if (segmentMode === 'preview' || allowSelection) {
-              <img
-                [class.filmstrip-img]="segmentMode === 'preview'"
-                [class.current-segment]="
-                  segmentMode === 'preview' &&
-                  currentSegmentId === segment.av_segment_id
-                "
-                attr.id="segment-{{ segment.av_segment_id }}"
-                [class.current-segment]="
-                  currentSegmentId === segment.av_segment_id
-                "
-                src="{{ segment.segment_screenshot_uri.replace('.0', '') }}"
-              />
+              <div style="position: relative; display: inline-block">
+                <img
+                  [class.filmstrip-img]="segmentMode === 'preview'"
+                  [class.current-segment]="
+                    segmentMode === 'preview' &&
+                    currentSegmentId === segment.av_segment_id
+                  "
+                  attr.id="segment-{{ segment.av_segment_id }}"
+                  [class.current-segment]="
+                    currentSegmentId === segment.av_segment_id
+                  "
+                  src="{{ segment.segment_screenshot_uri.replace('.0', '') }}"
+                />
+                <div
+                  *ngIf="segment.legal_disclaimer_text"
+                  style="
+                    position: absolute;
+                    bottom: 8px;
+                    left: 50%;
+                    transform: translateX(-50%);
+                    background: rgba(0, 0, 0, 0.5);
+                    color: white;
+                    font-size: 0.85em;
+                    pointer-events: none;
+                    z-index: 10;
+                    padding: 2px 6px;
+                  "
+                >
+                  {{ segment.legal_disclaimer_text }}
+                </div>
+              </div>
             } @else {
               <div style="position: relative">
                 <video
@@ -109,6 +128,23 @@ limitations under the License.
                   class="video-canvas"
                   attr.id="vid-{{ segment.av_segment_id }}"
                 ></canvas>
+                <div
+                  *ngIf="segment.legal_disclaimer_text"
+                  style="
+                    position: absolute;
+                    bottom: 8px;
+                    left: 50%;
+                    transform: translateX(-50%);
+                    background: rgba(0, 0, 0, 0.5);
+                    color: white;
+                    font-size: 0.85em;
+                    pointer-events: none;
+                    z-index: 10;
+                    padding: 2px 6px;
+                  "
+                >
+                  {{ segment.legal_disclaimer_text }}
+                </div>
               </div>
             }
             <mat-icon class="selection-icon" *ngIf="allowSelection">
@@ -117,12 +153,6 @@ limitations under the License.
             <mat-chip *ngIf="segmentMode === 'preview'" class="duration-chip"
               >{{ segment.duration_s.toFixed(2) }}s</mat-chip
             >
-            <div
-              *ngIf="segment.legal_disclaimer_text"
-              style="position: absolute; bottom: 8px; left: 50%; transform: translateX(-50%); background: rgba(0,0,0,0.5); color: white; font-size: 0.85em; pointer-events: none; z-index: 10;"
-            >
-              {{ segment.legal_disclaimer_text }}
-            </div>
           </div>
           <div class="current-segment-info" *ngIf="segmentMode === 'segments'">
             <span class="segment-number">

--- a/ui/src/ui/src/app/segments-list/segments-list.component.html
+++ b/ui/src/ui/src/app/segments-list/segments-list.component.html
@@ -118,7 +118,7 @@ limitations under the License.
               >{{ segment.duration_s.toFixed(2) }}s</mat-chip
             >
             <div
-              *ngIf="segmentMode === 'preview' && segment.legal_disclaimer_text"
+              *ngIf="segment.legal_disclaimer_text"
               style="position: absolute; bottom: 8px; left: 50%; transform: translateX(-50%); background: rgba(0,0,0,0.5); color: white; font-size: 0.85em; pointer-events: none; z-index: 10;"
             >
               {{ segment.legal_disclaimer_text }}

--- a/ui/src/ui/src/app/segments-list/segments-list.component.ts
+++ b/ui/src/ui/src/app/segments-list/segments-list.component.ts
@@ -239,7 +239,12 @@ export class SegmentsListComponent {
       (seg: AvSegment) => seg.av_segment_id === segmentId
     );
     if (segment) {
-      segment.legal_disclaimer_text = this.legalDisclaimerTexts[segmentId];
+      const text = this.legalDisclaimerTexts[segmentId]?.trim();
+      if (text) {
+        segment.legal_disclaimer_text = text;
+      } else {
+        delete segment.legal_disclaimer_text;
+      }
     }
   }
 }

--- a/ui/src/ui/src/app/segments-list/segments-list.component.ts
+++ b/ui/src/ui/src/app/segments-list/segments-list.component.ts
@@ -22,6 +22,7 @@ import {
 } from '@angular/cdk/drag-drop';
 import { ScrollingModule } from '@angular/cdk/scrolling';
 import { CommonModule } from '@angular/common';
+import { FormsModule } from '@angular/forms';
 import {
   Component,
   ElementRef,
@@ -49,6 +50,7 @@ import {
   standalone: true,
   imports: [
     CommonModule,
+    FormsModule,
     MatButtonModule,
     MatButtonToggleModule,
     MatChipsModule,
@@ -78,6 +80,7 @@ export class SegmentsListComponent {
   segmentCanvasElems?: QueryList<ElementRef<HTMLCanvasElement>>;
 
   segmentMarkerPositions: Record<string, number[]> = {};
+  legalDisclaimerTexts: Record<string, string> = {};
   splitting = false;
 
   CONFIG = CONFIG;
@@ -229,5 +232,14 @@ export class SegmentsListComponent {
       (segment: AvSegment) => segment.av_segment_id === segmentId
     ).splitting = true;
     this.clearSegmentMarkers(segmentId);
+  }
+
+  applyLegalDisclaimer(segmentId: string) {
+    const segment = this.segmentList!.find(
+      (seg: AvSegment) => seg.av_segment_id === segmentId
+    );
+    if (segment) {
+      segment.legal_disclaimer_text = this.legalDisclaimerTexts[segmentId];
+    }
   }
 }


### PR DESCRIPTION
## Summary
- allow segments to store legal disclaimer text
- show disclaimer input in segment list
- display disclaimer overlay in preview mode
- include disclaimer text when adding segments to render queue
- pass disclaimer data through combiner and overlay text during ffmpeg render

## Testing
- `python3 -m py_compile service/combiner/combiner.py service/video/video.py`
- `npx tsc -p tsconfig.json` *(fails: Cannot find name 'require')*

------
https://chatgpt.com/codex/tasks/task_e_6888c802e0cc8332aadff5c5bedf954c