### PR TITLE
Add legal text overlay to video

### DIFF
--- a/service/combiner/combiner.py
+++ b/service/combiner/combiner.py
@@ -54,6 +54,8 @@ class VideoVariantRenderSettings:
       audio track portions.
     fade_out: Whether to fade out the end of the video variant.
     overlay_type: How to overlay music / audio for the variant.
+    enable_text_overlay: Whether to enable text overlay on the video.
+    overlay_text: The text to overlay on the video.
   """
 
   generate_image_assets: bool = False
@@ -63,6 +65,8 @@ class VideoVariantRenderSettings:
   use_continuous_audio: bool = False
   fade_out: bool = False
   overlay_type: Utils.RenderOverlayType = None
+  enable_text_overlay: bool = False
+  overlay_text: str = 'T&Cs apply. Gamble responsibly.'
 
   def __init__(self, **kwargs):
     field_names = set([f.name for f in dataclasses.fields(self)])
@@ -79,7 +83,9 @@ class VideoVariantRenderSettings:
         f'use_music_overlay={self.use_music_overlay}, '
         f'use_continuous_audio={self.use_continuous_audio}, '
         f'fade_out={self.fade_out}, '
-        f'overlay_type={self.overlay_type})'
+        f'overlay_type={self.overlay_type}, '
+        f'enable_text_overlay={self.enable_text_overlay}, '
+        f'overlay_text={self.overlay_text})'
     )
 
 
@@ -739,16 +745,26 @@ def _render_video_variant(
       Utils.RenderFormatType.SQUARE.value
       in video_variant.render_settings.formats
   ):
+    blur_filter = ConfigService.FFMPEG_SQUARE_BLUR_FILTER
+    if video_variant.render_settings.enable_text_overlay:
+      blur_filter = _get_text_overlay_filter(
+          video_variant.render_settings.overlay_text, blur_filter
+      )
     formats_to_render[Utils.RenderFormatType.SQUARE.value] = {
-        'blur_filter': ConfigService.FFMPEG_SQUARE_BLUR_FILTER,
+        'blur_filter': blur_filter,
         'crop_file_path': square_video_file_path
     }
   if (
       Utils.RenderFormatType.VERTICAL.value
       in video_variant.render_settings.formats
   ):
+    blur_filter = ConfigService.FFMPEG_VERTICAL_BLUR_FILTER
+    if video_variant.render_settings.enable_text_overlay:
+      blur_filter = _get_text_overlay_filter(
+          video_variant.render_settings.overlay_text, blur_filter
+      )
     formats_to_render[Utils.RenderFormatType.VERTICAL.value] = {
-        'blur_filter': ConfigService.FFMPEG_VERTICAL_BLUR_FILTER,
+        'blur_filter': blur_filter,
         'crop_file_path': vertical_video_file_path
     }
   for format_type, format_instructions in formats_to_render.items():
@@ -809,6 +825,30 @@ def _render_video_variant(
       result['images'][format_type] = rendered_path['images']
 
   return result
+
+
+def _get_text_overlay_filter(overlay_text: str, video_filter: str) -> str:
+  """Generates an FFmpeg filter with text overlay.
+  
+  Args:
+    overlay_text: The text to overlay on the video.
+    video_filter: The existing video filter to extend.
+    
+  Returns:
+    The video filter with text overlay added.
+  """
+  # Escape special characters in the text for FFmpeg
+  escaped_text = overlay_text.replace(':', '\\:').replace("'", "\\'")
+  
+  # Add text overlay to the bottom center of the video
+  text_filter = f"drawtext=text='{escaped_text}':fontsize=24:fontcolor=white:x=(w-text_w)/2:y=h-th-20:box=1:boxcolor=black@0.5:boxborderw=5"
+  
+  if video_filter:
+    # If there's an existing filter, chain the text overlay after it
+    return f"{video_filter},{text_filter}"
+  else:
+    # If no existing filter, just use the text overlay
+    return text_filter
 
 
 def _get_variant_ffmpeg_commands(
@@ -1383,12 +1423,18 @@ def _build_ffmpeg_filters(
     case Utils.RenderOverlayType.VARIANT_START.value | _:
       overlay_start = variant_first_segment_start
 
+  # Add text overlay if enabled
+  text_overlay_filter = ''
+  if render_settings.enable_text_overlay:
+    escaped_text = render_settings.overlay_text.replace(':', '\\:').replace("'", "\\'")
+    text_overlay_filter = f";[outv]drawtext=text='{escaped_text}':fontsize=24:fontcolor=white:x=(w-text_w)/2:y=h-th-20:box=1:boxcolor=black@0.5:boxborderw=5[outv]"
+
   full_av_select_filter = ''.join(
       video_select_filter + audio_select_filter + select_filter_concat
-      + [f'concat=n={idx}:v=1:a=1[outv][outa]', fade_out_filter]
+      + [f'concat=n={idx}:v=1:a=1[outv][outa]', fade_out_filter, text_overlay_filter]
   ) if has_audio else ''.join(
       video_select_filter + select_filter_concat
-      + [f'concat=n={idx}:v=1[outv]']
+      + [f'concat=n={idx}:v=1[outv]', text_overlay_filter]
   )
 
   music_overlay_select_filter = ''.join(
@@ -1400,6 +1446,7 @@ def _build_ffmpeg_filters(
           f'concat=n={idx}:v=1:a=1[outv][tempa];',
           '[tempa][music]amerge=inputs=2[outa]',
           fade_out_filter,
+          text_overlay_filter,
       ]
   ) if has_audio else ''
   continuous_audio_select_filter = ''.join(
@@ -1407,7 +1454,7 @@ def _build_ffmpeg_filters(
           f"[0:a]aselect='between(t,{overlay_start},{overlay_start+duration})'"
           ',asetpts=N/SR/TB[outa];'
       ] + [entry for entry in select_filter_concat if entry.startswith('[v')]
-      + [f'concat=n={idx}:v=1[outv]', fade_out_filter]
+      + [f'concat=n={idx}:v=1[outv]', fade_out_filter, text_overlay_filter]
   ) if has_audio else ''
 
   return (

--- a/ui/src/ui/src/app/api-calls/api-calls.service.interface.ts
+++ b/ui/src/ui/src/app/api-calls/api-calls.service.interface.ts
@@ -80,6 +80,8 @@ export interface RenderSettings {
   use_continuous_audio: boolean;
   fade_out: boolean;
   overlay_type?: OverlayType;
+  enable_text_overlay?: boolean;
+  overlay_text?: string;
 }
 
 export interface RenderQueue {

--- a/ui/src/ui/src/app/app.component.css
+++ b/ui/src/ui/src/app/app.component.css
@@ -77,6 +77,21 @@ segments-list {
   pointer-events: none;
 }
 
+.text-overlay {
+  position: absolute;
+  bottom: 20px;
+  left: 50%;
+  transform: translateX(-50%);
+  background-color: rgba(0, 0, 0, 0.5);
+  color: white;
+  padding: 5px 10px;
+  border-radius: 5px;
+  font-size: 14px;
+  font-weight: bold;
+  pointer-events: none;
+  z-index: 10;
+}
+
 .canvas-drag-element {
   cursor: move;
   overflow: hidden;

--- a/ui/src/ui/src/app/app.component.html
+++ b/ui/src/ui/src/app/app.component.html
@@ -328,6 +328,12 @@ limitations under the License.
               default
             />
           </video>
+          <div 
+            *ngIf="enableTextOverlay"
+            class="text-overlay"
+          >
+            {{ overlayText }}
+          </div>
           <canvas #magicCanvas></canvas>
           <div
             #canvasDragElement
@@ -576,6 +582,19 @@ limitations under the License.
                 Fade out
               </mat-checkbox>
             </span>
+          </div>
+          <div class="user-settings" style="margin-top: 8px">
+            <span matTooltip="Add text overlay to the video">
+              <mat-checkbox color="primary" [(ngModel)]="enableTextOverlay">
+                Enable text overlay
+              </mat-checkbox>
+            </span>
+          </div>
+          <div *ngIf="enableTextOverlay" style="margin-top: 8px">
+            <mat-form-field subscriptSizing="dynamic" style="width: 100%">
+              <mat-label>Overlay text:</mat-label>
+              <input matInput [(ngModel)]="overlayText" placeholder="Enter text to overlay">
+            </mat-form-field>
           </div>
           <div class="user-settings">
             <mat-checkbox color="primary" [(ngModel)]="demandGenAssets">

--- a/ui/src/ui/src/app/app.component.ts
+++ b/ui/src/ui/src/app/app.component.ts
@@ -155,6 +155,8 @@ export class AppComponent {
   overlaySettings: OverlayType = 'variant_start';
   fadeOut = false;
   demandGenAssets = true;
+  enableTextOverlay = false;
+  overlayText = 'T&Cs apply. Gamble responsibly.';
   analyseAudio = true;
   previousRuns: string[] | undefined;
   previousRenders: PreviousRender[] | undefined;
@@ -615,6 +617,8 @@ export class AppComponent {
     this.fadeOut = false;
     this.allSegmentsToggle = false;
     this.demandGenAssets = true;
+    this.enableTextOverlay = false;
+    this.overlayText = 'T&Cs apply. Gamble responsibly.';
     this.analyseAudio = true;
     this.segmentMarkers = {};
     this.previewVideoElem.nativeElement.pause();
@@ -1107,6 +1111,8 @@ export class AppComponent {
       use_continuous_audio: this.audioSettings === 'continuous',
       fade_out: this.fadeOut,
       overlay_type: this.overlaySettings,
+      enable_text_overlay: this.enableTextOverlay,
+      overlay_text: this.overlayText,
     };
     const selectedScenes = selectedSegments.map(
       (segment: AvSegment) => segment.av_segment_id
@@ -1178,6 +1184,8 @@ export class AppComponent {
         : 'segment';
     this.fadeOut = variant.render_settings.fade_out;
     this.overlaySettings = variant.render_settings.overlay_type!;
+    this.enableTextOverlay = variant.render_settings.enable_text_overlay || false;
+    this.overlayText = variant.render_settings.overlay_text || 'T&Cs apply. Gamble responsibly.';
     this.closeRenderQueueSidenav();
     setTimeout(() => {
       this.loadingVariant = false;

--- a/ui/src/ui/src/app/video-combo/video-combo.component.css
+++ b/ui/src/ui/src/app/video-combo/video-combo.component.css
@@ -33,6 +33,26 @@ video {
   border-radius: 14px;
 }
 
+.video-container {
+  position: relative;
+  display: inline-block;
+}
+
+.text-overlay {
+  position: absolute;
+  bottom: 20px;
+  left: 50%;
+  transform: translateX(-50%);
+  background-color: rgba(0, 0, 0, 0.5);
+  color: white;
+  padding: 5px 10px;
+  border-radius: 5px;
+  font-size: 14px;
+  font-weight: bold;
+  pointer-events: none;
+  z-index: 10;
+}
+
 .score-1 {
   color: #b71c1c;
 }

--- a/ui/src/ui/src/app/video-combo/video-combo.component.html
+++ b/ui/src/ui/src/app/video-combo/video-combo.component.html
@@ -65,14 +65,21 @@ limitations under the License.
       >
     </div>
   }
-  <video
-    class="mat-elevation-z8"
-    [style.margin-right]="showApprovalStatus ? 'auto' : ''"
-    #videoElem
-    controls
-  >
-    <source src="" />
-  </video>
+  <div class="video-container" [style.margin-right]="showApprovalStatus ? 'auto' : ''">
+    <video
+      class="mat-elevation-z8"
+      #videoElem
+      controls
+    >
+      <source src="" />
+    </video>
+    <div 
+      *ngIf="combo.render_settings && combo.render_settings.enable_text_overlay"
+      class="text-overlay"
+    >
+      {{ combo.render_settings.overlay_text }}
+    </div>
+  </div>
 </div>
 <div class="row" style="justify-content: start">
   Segments: {{ combo.scenes }}
@@ -97,6 +104,13 @@ limitations under the License.
         : 'Individual segments') +
       (combo.render_settings.fade_out ? ' + Fade out' : '')
   }}
+</div>
+<div
+  class="row"
+  style="justify-content: start; margin-top: 0"
+  *ngIf="combo.render_settings && combo.render_settings.enable_text_overlay"
+>
+  Text overlay: "{{ combo.render_settings.overlay_text }}"
 </div>
 <div class="row" style="justify-content: start">
   {{ combo.description }}


### PR DESCRIPTION
<!-- One very short sentence on the WHAT and WHY of the PR. E.g. "Remove pathHash attribute because it is confirmed unused." or "Add DNS round robin to improve load distribution." -->
Add text overlay feature to video previews and final renders.

<!-- OPTIONAL: If the WHY of the PR is not obvious, perhaps because it fixed a gnarly bug, explain it in a short paragraph here. E.g. "Commit a73bb98 introduced a bug where the class list was filtered to only work for MDC files, hence we partially revert it here." -->
This feature allows users to include custom text, such as legal disclaimers ("T&Cs apply. Gamble responsibly."), positioned at the bottom center of the video for both preview and final output.

---
<a href="https://cursor.com/background-agent?bcId=bc-86337d4d-2905-4307-bc9c-c5c411d695d2">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-86337d4d-2905-4307-bc9c-c5c411d695d2">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

<sub>[Learn more](https://docs.cursor.com/background-agent/web-and-mobile) about Cursor Agents</sub>